### PR TITLE
<#10> feat : Post Api 페이지네이션 구현 

### DIFF
--- a/server/src/api/posts/post.ctrl.js
+++ b/server/src/api/posts/post.ctrl.js
@@ -18,9 +18,23 @@ export const checkPostId = (ctx, next) => {
 
 // GET api/posts
 export const list = async ctx => {
+  const page = parseInt(ctx.query.page || '1', 10);
+
   try {
-    const posts = await Post.find().exec();
-    ctx.body = posts;
+    const posts = await Post.find()
+      .sort({ _id: -1 })
+      .limit(10)
+      .skip((page - 1) * 10)
+      .lean()
+      .exec();
+
+    const postCount = await Post.countDocuments().exec();
+    ctx.set('Last-page', Math.ceil(postCount / 10));
+    ctx.body = posts.map(post => ({
+      ...post,
+      body:
+        post.body.length > 200 ? `${post.body.slice(0, 200)}...` : post.body,
+    }));
   } catch (e) {
     ctx.throw(500, e);
   }

--- a/server/src/lib/utils/createFakeData.js
+++ b/server/src/lib/utils/createFakeData.js
@@ -1,0 +1,17 @@
+import Post from '../../models/posts';
+
+export default async function createFakeData() {
+  const exist = await Post.find().exec();
+
+  if (exist.length > 0) {
+    return;
+  }
+
+  const posts = [...Array(40).keys()].map(i => ({
+    title: `포스트 ${i}`,
+    body: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.',
+    tags: ['태그1', '태그2'],
+  }));
+
+  Post.insertMany(posts);
+}


### PR DESCRIPTION
## 내용
- Post API 페이지네이션 기능 추가
- 내용 길이 제한 : body 내용이 200자가 넘어가면 `...`으로 축약
- 마지막 페이지 번호 알려주기 : 커스텀 헤더를 설정하여 마지막 페이지 번호를 알려주기
- 한 페이지 당 10개의 포스트를 보여줍니다. 

### 관련 이슈
#10