### PR TITLE
<#31> Fix :  [백엔드] register 요청 시 409에러  

### DIFF
--- a/server/src/api/auth/auth.ctrl.js
+++ b/server/src/api/auth/auth.ctrl.js
@@ -25,7 +25,8 @@ export const register = async ctx => {
   const { username, password } = ctx.request.body;
 
   try {
-    const exists = User.findByUsername(username);
+    const exists = await User.findByUsername(username).exec();
+
     if (exists) {
       ctx.status = 409; // Conflict
       return;


### PR DESCRIPTION
## 내용
- bug : api/auth/register 요청 시 409에러  
- fix : promise 객체의 값을 받기 때매 에러 발새 -> .exec()를 활용하여 해결

### 관련 이슈
- Resolve: #30 #31
