### PR TITLE
<#38> feat : 인증 에러 메세지 구현

### DIFF
--- a/client/src/customs/errorMessage.js
+++ b/client/src/customs/errorMessage.js
@@ -1,0 +1,17 @@
+import styled, { css } from 'styled-components';
+
+import { Center } from '../layout/flexbox';
+
+export const ErrorMessage = styled(Center)`
+  background: none;
+  border: none;
+  outline: none;
+
+  ${({ theme }) => {
+    return css`
+      font-weight: ${theme.fontSizes.bold};
+      color: ${theme.color.red[400]};
+      padding: ${theme.space[4]};
+    `;
+  }}
+`;


### PR DESCRIPTION
## 내용
- 로그인, 회원가입 도중 일어날 수 있는 에러들에 대한 처리
- 아쉬운 점 : 에러 코드에 대한 세분화를 좀 더 잘했으면 사용자 입장에서 더 좋은 사용자 경험이 이루어 졌을 것이라고 판단

예) 401 에러(`Unauthorized`)
- 단순한 로그인 실패 에러이지만 로그인 실패하는 경우는 여러가지 경우가 있다. 
1. user가 DB에 존재하지 않을 경우
2. 비밀번호가 틀렸을 경우

=> 여기에 대한 세분화 과정이 이루어졌으면 더 좋을 것 같다. 

---


### 관련 이슈
#38 #32 #36 